### PR TITLE
feat(galaxy-collections): Support Ansible Galaxy collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,3 +221,20 @@ LANG=
 
 Assignments with an empty value are filled from the parent environment (your shell).
 If the variable doesn't exist in the parent environment, it is ignored.
+
+### Ansible Galaxy Collections
+
+The `playbook.sh` script takes a variable `ANSIBLE_GALAXY_COLLECTIONS` and installs the contained
+collections (separated by spaces) if they do not already exist in
+`$HOME/.ansible/collections/ansible_collections`.
+The `ANSIBLE_GALAXY_COLLECTIONS` variable can be given
+
+- as an environment variable when, or
+- as a variable in the `environment` file.
+
+Example:
+
+```bash
+# ./environment
+ANSIBLE_GALAXY_COLLECTIONS=community.general community.crypto community.mysql
+```

--- a/playbook.sh
+++ b/playbook.sh
@@ -73,5 +73,15 @@ else
 fi
 trap 'rm ./.playbook.yml' INT TERM EXIT
 
+export "${environment[@]}"
+
+for collection in ${ANSIBLE_GALAXY_COLLECTIONS:-}; do
+	echo "[playbook.sh] Installing ansible-galaxy dependency \"${collection}\" ..."
+	# Replace . by /
+	[ ! -e $HOME/.ansible/collections/ansible_collections/"${collection//\./\//}" ] \
+		&& ansible-galaxy collection install "$collection"
+done
+
 # Go!
-exec env - "${environment[@]}" "${ANSIBLE_PLAYBOOK:-ansible-playbook}" "${@}" "./.playbook.yml"
+echo "[playbook.sh] Running playbook ..."
+exec "${ANSIBLE_PLAYBOOK:-ansible-playbook}" "${@}" "./.playbook.yml"


### PR DESCRIPTION
This commit adds support for Ansible Galaxy collections to `playbook.sh`. The `playbook.sh` script takes a variable `ANSIBLE_GALAXY_COLLECTIONS` and installs the contained collections (separated by spaces) if they do not already exist in `/home/haslersn/.ansible/collections/ansible_collections`. The `ANSIBLE_GALAXY_COLLECTIONS` variable can be given

* as an environment variable when, or
* as a variable in the `environment` file.

Example:

```
# ./environment
ANSIBLE_GALAXY_COLLECTIONS=community.general community.crypto community.mysql
```