### PR TITLE
fix(shell.nix): Add bashInteractive to shell.nix inputs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -131,6 +131,7 @@ pkgs.stdenvNoCC.mkDerivation {
 
   nativeBuildInputs = with pkgs; [
     ansible
+    bashInteractive
     hugo
     jq
     kapply


### PR DESCRIPTION
This is recommended when using lorri
For newer versions of lorri it is required to have bash completions