### PR TITLE
feat(inventory): Prohibit overwriting with a different type

### DIFF
--- a/inventory.py
+++ b/inventory.py
@@ -62,7 +62,7 @@ def mergeDict(a, b, overwrite=True):
         mergeDict(a[key], b[key], overwrite=overwrite)
       elif isinstance(a[key], list) and isinstance(b[key], list):
         a[key] = a[key] + b[key]
-      elif overwrite == False:
+      elif overwrite == False or type(a[key]) != type(b[key]):
         if a[key] != b[key]:
           raise InventoryErrors(f'There are conflicting definitions for `{key}`: `{a[key]}` and `{b[key]}`')
       else:


### PR DESCRIPTION
Overwriting a variable is now only allowed if both have the same type. This prevents, e.g., overwriting a list (or dict) with a string where the latter should have been a drop-in list (or dict).